### PR TITLE
CCD-203 Fix: Invoice currency display

### DIFF
--- a/src/service/invoiceService.ts
+++ b/src/service/invoiceService.ts
@@ -75,8 +75,8 @@ export const createInvoiceService = async (
     id: '1',
     name: 'Cult Creative',
     fullAddress:
-      '4-402, Level 4, The Starling Mall, Lot 4-401 &, 6, Jalan SS 21/37, Damansara Utama, 47400 Petaling Jaya, Selangor',
-    phoneNumber: '+60 11-5415 5751',
+      '5-3A, Block A, Jaya One, No.72A, Jalan Universiti, 46200 Petaling Jaya, Selangor',
+    phoneNumber: '(+60)12-849 6499',
     company: 'Cult Creative',
     addressType: 'Hq',
     email: 'support@cultcreative.asia',


### PR DESCRIPTION
# Summary
This pull request introduces enhancements to the invoice-related endpoints to include the creator's agreement currency in API responses. Additionally, it updates the company information used in invoice generation.

## Changes

### 1. Invoice Controller Enhancements
- Add currency field to invoice responses:
  - When fetching invoices (`getAllInvoices`, `getInvoicesByCampaignId`), the API now maps each invoice to include the currency from the relevant creatorAgreement, if available.
  - For `getInvoicesByCreatorId`, the relevant creatorAgreement is included in the campaign response.
  - For `getInvoiceById` and `creatorInvoice`, the campaign’s creatorAgreement is filtered by the invoice’s creatorId and campaignId to ensure the correct currency is retrieved.
- Extended Prisma queries:
  - Invoice queries now include the creatorAgreement relation in relevant places to allow extracting the currency.
  - Added logic to retrieve the creator ID before fetching the invoice details to correctly filter the agreement.

### 2. Company Information Update
- Updated the default company address and phone number in `createInvoiceService` (in invoiceService.ts) to:
  - Address: 5-3A, Block A, Jaya One, No.72A, Jalan Universiti, 46200 Petaling Jaya, Selangor
  - Phone Number: (+60)12-849 6499