### PR TITLE
Fix: V4 Submissions Iterations - v1

### DIFF
--- a/src/controller/clientController.ts
+++ b/src/controller/clientController.ts
@@ -311,7 +311,7 @@ export const createClientCampaign = async (req: Request, res: Response) => {
       videoAngle,
       campaignDo,
       campaignDont,
-      submissionVersion,
+      // submissionVersion,
     } = campaignData;
 
     // Validate required fields
@@ -371,7 +371,7 @@ export const createClientCampaign = async (req: Request, res: Response) => {
         description: campaignDescription,
         status: 'PENDING_CSM_REVIEW', // Set to PENDING_CSM_REVIEW so it shows up in the Pending tab for admins
         origin: 'CLIENT', // Mark as client-created campaign for v3 flow
-        submissionVersion: submissionVersion || 'v3', // Set submission version to determine flow type
+        submissionVersion: 'v4', // Set submission version to determine flow type
         brandTone: brandTone || '',
         productName: productName || '',
         // Skip adminManager and other fields that will be set by CSM later

--- a/src/controller/submissionController.ts
+++ b/src/controller/submissionController.ts
@@ -610,6 +610,7 @@ export const getAllSubmissions = async (req: Request, res: Response) => {
         campaign: {
           select: {
             name: true,
+            company: true,
           },
         },
         admin: {

--- a/src/controller/submissionController.ts
+++ b/src/controller/submissionController.ts
@@ -314,6 +314,17 @@ export const adminManageAgreementSubmission = async (req: Request, res: Response
         },
       });
 
+      // Update the corresponding pitch status to AGREEMENT_SUBMITTED when agreement is approved
+      await prisma.pitch.updateMany({
+        where: {
+          campaignId: campaignId,
+          userId: userId,
+          status: 'AGREEMENT_PENDING',
+        },
+        data: {
+          status: 'AGREEMENT_SUBMITTED',
+        },
+      });
 
       const taskInReviewColumn = inReviewColumn?.task?.find((item) => item.submissionId === agreementSubs.id);
 
@@ -464,6 +475,18 @@ export const adminManageAgreementSubmission = async (req: Request, res: Response
               },
             },
           },
+        },
+      });
+
+      // Update the corresponding pitch status back to AGREEMENT_PENDING when agreement is rejected
+      await prisma.pitch.updateMany({
+        where: {
+          campaignId: campaignId,
+          userId: userId,
+          status: 'AGREEMENT_SUBMITTED',
+        },
+        data: {
+          status: 'AGREEMENT_PENDING',
         },
       });
 


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes across campaign creation, submission handling, and agreement management. The most significant changes include updating the campaign flow to use the latest submission version, refining the logic for handling status updates in V4 content submissions, and synchronizing pitch status with agreement approvals and rejections. Additionally, campaign data retrieval now includes company information.

**Campaign Flow Updates:**
* The `createClientCampaign` logic now always sets `submissionVersion` to `'v4'`, ensuring all new client campaigns use the latest submission flow.
* The `submissionVersion` field is no longer destructured from incoming campaign data, reducing confusion and enforcing the new flow.

**Agreement and Pitch Status Synchronization:**
* When an agreement is approved, the corresponding pitch status is updated from `AGREEMENT_PENDING` to `AGREEMENT_SUBMITTED` for better workflow tracking.
* If an agreement is rejected, the pitch status is reverted from `AGREEMENT_SUBMITTED` back to `AGREEMENT_PENDING`, maintaining consistency.

**Campaign Data Enhancement:**
* The campaign data returned by `getAllSubmissions` now includes the `company` field, providing more context for each campaign.

#### Refer to: #255 